### PR TITLE
Add freeze avoidance control option

### DIFF
--- a/src/engine/shared/config_variables_tclient.h
+++ b/src/engine/shared/config_variables_tclient.h
@@ -46,6 +46,8 @@ MACRO_CONFIG_INT(TcPredMarginInFreeze, tc_pred_margin_in_freeze, 0, 0, 1, CFGFLA
 MACRO_CONFIG_INT(TcPredMarginInFreezeAmount, tc_pred_margin_in_freeze_amount, 15, 0, 2000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Set what your prediction margin while frozen should be")
 
 MACRO_CONFIG_INT(TcAvoidFreeze, tc_avoid_freeze, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Automatically walk away from nearby freeze tiles")
+MACRO_CONFIG_INT(TcAvoidFreezeRangeTiles, tc_avoid_freeze_range_tiles, 2, 1, 8, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How many tiles ahead to scan for freeze while auto-avoiding")
+MACRO_CONFIG_INT(TcAvoidFreezeReleaseHook, tc_avoid_freeze_release_hook, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Release hook automatically if it grabs a freeze tile while avoiding")
 
 MACRO_CONFIG_INT(TcShowOthersGhosts, tc_show_others_ghosts, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ghosts for other players in their unpredicted position")
 MACRO_CONFIG_INT(TcSwapGhosts, tc_swap_ghosts, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show predicted players as ghost and normal players as unpredicted")

--- a/src/engine/shared/config_variables_tclient.h
+++ b/src/engine/shared/config_variables_tclient.h
@@ -45,6 +45,8 @@ MACRO_CONFIG_INT(TcUnpredOthersInFreeze, tc_unpred_others_in_freeze, 0, 0, 1, CF
 MACRO_CONFIG_INT(TcPredMarginInFreeze, tc_pred_margin_in_freeze, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable changing prediction margin while frozen")
 MACRO_CONFIG_INT(TcPredMarginInFreezeAmount, tc_pred_margin_in_freeze_amount, 15, 0, 2000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Set what your prediction margin while frozen should be")
 
+MACRO_CONFIG_INT(TcAvoidFreeze, tc_avoid_freeze, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Automatically walk away from nearby freeze tiles")
+
 MACRO_CONFIG_INT(TcShowOthersGhosts, tc_show_others_ghosts, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ghosts for other players in their unpredicted position")
 MACRO_CONFIG_INT(TcSwapGhosts, tc_swap_ghosts, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show predicted players as ghost and normal players as unpredicted")
 MACRO_CONFIG_INT(TcHideFrozenGhosts, tc_hide_frozen_ghosts, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Hide Ghosts of other players if they are frozen")

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -11,10 +11,59 @@
 #include <game/client/components/scoreboard.h>
 #include <game/client/gameclient.h>
 #include <game/collision.h>
+#include <game/mapitems.h>
 
 #include <base/vmath.h>
 
 #include "controls.h"
+
+namespace
+{
+bool IsFreezeTileIndex(int Index)
+{
+        return Index == TILE_FREEZE || Index == TILE_DFREEZE || Index == TILE_LFREEZE;
+}
+
+bool IsFreezeTileAtMapPos(const CCollision *pCollision, int MapX, int MapY)
+{
+        if(!pCollision)
+                return false;
+        if(MapX < 0 || MapY < 0 || MapX >= pCollision->GetWidth() || MapY >= pCollision->GetHeight())
+                return false;
+
+        return IsFreezeTileIndex(pCollision->GetTile(MapX, MapY)) || IsFreezeTileIndex(pCollision->GetFrontTile(MapX, MapY));
+}
+
+bool IsFreezeAtPosition(const CCollision *pCollision, vec2 Pos)
+{
+        const int MapX = round_to_int(Pos.x) / 32;
+        const int MapY = round_to_int(Pos.y) / 32;
+        return IsFreezeTileAtMapPos(pCollision, MapX, MapY);
+}
+
+bool HasFreezeInDirection(const CCollision *pCollision, vec2 BasePos, int Direction)
+{
+        if(Direction == 0 || !pCollision)
+                return false;
+
+        const float PhysicalSize = CCharacterCore::PhysicalSize();
+        const float HalfSize = PhysicalSize / 2.0f;
+        const float HorizontalOffsets[] = {HalfSize + 6.0f, HalfSize + 22.0f};
+        const float VerticalOffsets[] = {-HalfSize * 0.75f, 0.0f, HalfSize * 0.75f};
+
+        for(float Horizontal : HorizontalOffsets)
+        {
+                const vec2 HorizontalPos = BasePos + vec2(Direction * Horizontal, 0.0f);
+                for(float Vertical : VerticalOffsets)
+                {
+                        if(IsFreezeAtPosition(pCollision, HorizontalPos + vec2(0.0f, Vertical)))
+                                return true;
+                }
+        }
+
+        return false;
+}
+} // namespace
 
 CControls::CControls()
 {
@@ -259,12 +308,36 @@ int CControls::SnapInput(int *pData)
 		m_aInputData[g_Config.m_ClDummy].m_Direction = 0;
 		if(m_aInputDirectionLeft[g_Config.m_ClDummy] && !m_aInputDirectionRight[g_Config.m_ClDummy])
 			m_aInputData[g_Config.m_ClDummy].m_Direction = -1;
-		if(!m_aInputDirectionLeft[g_Config.m_ClDummy] && m_aInputDirectionRight[g_Config.m_ClDummy])
-			m_aInputData[g_Config.m_ClDummy].m_Direction = 1;
+                if(!m_aInputDirectionLeft[g_Config.m_ClDummy] && m_aInputDirectionRight[g_Config.m_ClDummy])
+                        m_aInputData[g_Config.m_ClDummy].m_Direction = 1;
 
-		// dummy copy moves
-		if(g_Config.m_ClDummyCopyMoves)
-		{
+                if(g_Config.m_TcAvoidFreeze && GameClient()->m_Snap.m_LocalClientId >= 0 && GameClient()->m_Snap.m_pLocalCharacter)
+                {
+                        const auto &LocalClient = GameClient()->m_aClients[GameClient()->m_Snap.m_LocalClientId];
+                        const bool Frozen = LocalClient.m_Predicted.m_FreezeEnd != 0 || LocalClient.m_Predicted.m_DeepFrozen;
+                        if(!Frozen)
+                        {
+                                const CCollision *pCollision = GameClient()->Collision();
+                                const vec2 BasePos = GameClient()->m_LocalCharacterPos;
+                                if(!IsFreezeAtPosition(pCollision, BasePos))
+                                {
+                                        const int DesiredDir = m_aInputData[g_Config.m_ClDummy].m_Direction;
+                                        if(DesiredDir != 0)
+                                        {
+                                                const bool FreezeAhead = HasFreezeInDirection(pCollision, BasePos, DesiredDir);
+                                                if(FreezeAhead)
+                                                {
+                                                        const bool FreezeBehind = HasFreezeInDirection(pCollision, BasePos, -DesiredDir);
+                                                        m_aInputData[g_Config.m_ClDummy].m_Direction = FreezeBehind ? 0 : -DesiredDir;
+                                                }
+                                        }
+                                }
+                        }
+                }
+
+                // dummy copy moves
+                if(g_Config.m_ClDummyCopyMoves)
+                {
 			CNetObj_PlayerInput *pDummyInput = &GameClient()->m_DummyInput;
 			pDummyInput->m_Direction = m_aInputData[g_Config.m_ClDummy].m_Direction;
 			pDummyInput->m_Hook = m_aInputData[g_Config.m_ClDummy].m_Hook;

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -1,5 +1,8 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <algorithm>
+#include <array>
+
 #include <base/math.h>
 
 #include <engine/client.h>
@@ -11,6 +14,7 @@
 #include <game/client/components/scoreboard.h>
 #include <game/client/gameclient.h>
 #include <game/collision.h>
+#include <game/gamecore.h>
 #include <game/mapitems.h>
 
 #include <base/vmath.h>
@@ -41,27 +45,32 @@ bool IsFreezeAtPosition(const CCollision *pCollision, vec2 Pos)
         return IsFreezeTileAtMapPos(pCollision, MapX, MapY);
 }
 
-bool HasFreezeInDirection(const CCollision *pCollision, vec2 BasePos, int Direction)
+bool HasFreezeInDirection(const CCollision *pCollision, vec2 BasePos, int Direction, float Range)
 {
-        if(Direction == 0 || !pCollision)
+        if(Direction == 0 || !pCollision || Range <= 0.0f)
                 return false;
 
         const float PhysicalSize = CCharacterCore::PhysicalSize();
         const float HalfSize = PhysicalSize / 2.0f;
-        const float HorizontalOffsets[] = {HalfSize + 6.0f, HalfSize + 22.0f};
-        const float VerticalOffsets[] = {-HalfSize * 0.75f, 0.0f, HalfSize * 0.75f};
+        const float StartOffset = HalfSize + 6.0f;
+        const float MaxOffset = StartOffset + Range;
+        const float Step = std::max(8.0f, Range / 3.0f);
+        static constexpr std::array<float, 5> s_aVerticalFractions = {-1.0f, -0.5f, 0.0f, 0.5f, 1.0f};
 
-        for(float Horizontal : HorizontalOffsets)
+        for(float Horizontal = StartOffset; Horizontal <= MaxOffset + 0.5f; Horizontal += Step)
         {
                 const vec2 HorizontalPos = BasePos + vec2(Direction * Horizontal, 0.0f);
-                for(float Vertical : VerticalOffsets)
+                for(float Fraction : s_aVerticalFractions)
                 {
-                        if(IsFreezeAtPosition(pCollision, HorizontalPos + vec2(0.0f, Vertical)))
+                        const vec2 SamplePos = HorizontalPos + vec2(0.0f, Fraction * HalfSize * 0.9f);
+                        if(IsFreezeAtPosition(pCollision, SamplePos))
                                 return true;
                 }
         }
 
-        return false;
+        // Ensure we always sample the farthest point even if the loop step skipped it.
+        const vec2 FarthestPos = BasePos + vec2(Direction * MaxOffset, 0.0f);
+        return IsFreezeAtPosition(pCollision, FarthestPos);
 }
 } // namespace
 
@@ -321,14 +330,38 @@ int CControls::SnapInput(int *pData)
                                 const vec2 BasePos = GameClient()->m_LocalCharacterPos;
                                 if(!IsFreezeAtPosition(pCollision, BasePos))
                                 {
-                                        const int DesiredDir = m_aInputData[g_Config.m_ClDummy].m_Direction;
-                                        if(DesiredDir != 0)
+                                        const float Range = g_Config.m_TcAvoidFreezeRangeTiles * 32.0f;
+                                        int DesiredDir = m_aInputData[g_Config.m_ClDummy].m_Direction;
+                                        int ApproachDir = DesiredDir;
+
+                                        if(ApproachDir == 0)
                                         {
-                                                const bool FreezeAhead = HasFreezeInDirection(pCollision, BasePos, DesiredDir);
+                                                const float HorizontalVelocity = LocalClient.m_Predicted.m_Vel.x;
+                                                if(absolute(HorizontalVelocity) > 1.0f)
+                                                {
+                                                        ApproachDir = HorizontalVelocity > 0.0f ? 1 : -1;
+                                                }
+                                                else if(LocalClient.m_Predicted.m_HookState == HOOK_GRABBED || LocalClient.m_Predicted.m_HookState == HOOK_FLYING)
+                                                {
+                                                        const float HookHorizontal = LocalClient.m_Predicted.m_HookPos.x - BasePos.x;
+                                                        if(absolute(HookHorizontal) > 4.0f)
+                                                                ApproachDir = HookHorizontal > 0.0f ? 1 : -1;
+                                                }
+                                        }
+
+                                        if(ApproachDir != 0)
+                                        {
+                                                const bool FreezeAhead = HasFreezeInDirection(pCollision, BasePos, ApproachDir, Range);
                                                 if(FreezeAhead)
                                                 {
-                                                        const bool FreezeBehind = HasFreezeInDirection(pCollision, BasePos, -DesiredDir);
-                                                        m_aInputData[g_Config.m_ClDummy].m_Direction = FreezeBehind ? 0 : -DesiredDir;
+                                                        const bool FreezeBehind = HasFreezeInDirection(pCollision, BasePos, -ApproachDir, Range);
+                                                        m_aInputData[g_Config.m_ClDummy].m_Direction = FreezeBehind ? 0 : -ApproachDir;
+
+                                                        if(g_Config.m_TcAvoidFreezeReleaseHook && LocalClient.m_Predicted.m_HookState == HOOK_GRABBED)
+                                                        {
+                                                                if(IsFreezeAtPosition(pCollision, LocalClient.m_Predicted.m_HookPos))
+                                                                        m_aInputData[g_Config.m_ClDummy].m_Hook = 0;
+                                                        }
                                                 }
                                         }
                                 }

--- a/src/game/client/components/tclient/menus_tclient.cpp
+++ b/src/game/client/components/tclient/menus_tclient.cpp
@@ -523,13 +523,14 @@ void CMenus::RenderSettingsTClientSettngs(CUIRect MainView)
 	else
 		Column.HSplitTop(LineSize * 2, nullptr, &Column);
 	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcUnpredOthersInFreeze, TCLocalize("Dont predict other players if you are frozen"), &g_Config.m_TcUnpredOthersInFreeze, &Column, LineSize);
-	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcPredMarginInFreeze, TCLocalize("Adjust your prediction margin while frozen"), &g_Config.m_TcPredMarginInFreeze, &Column, LineSize);
-	Column.HSplitTop(LineSize, &Button, &Column);
-	if(g_Config.m_TcPredMarginInFreeze)
-		Ui()->DoScrollbarOption(&g_Config.m_TcPredMarginInFreezeAmount, &g_Config.m_TcPredMarginInFreezeAmount, &Button, TCLocalize("Frozen Margin"), 0, 100, &CUi::ms_LinearScrollbarScale, 0, "ms");
-	s_SectionBoxes.back().h = Column.y - s_SectionBoxes.back().y;
+        DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcPredMarginInFreeze, TCLocalize("Adjust your prediction margin while frozen"), &g_Config.m_TcPredMarginInFreeze, &Column, LineSize);
+        Column.HSplitTop(LineSize, &Button, &Column);
+        if(g_Config.m_TcPredMarginInFreeze)
+                Ui()->DoScrollbarOption(&g_Config.m_TcPredMarginInFreezeAmount, &g_Config.m_TcPredMarginInFreezeAmount, &Button, TCLocalize("Frozen Margin"), 0, 100, &CUi::ms_LinearScrollbarScale, 0, "ms");
+        DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcAvoidFreeze, TCLocalize("Automatically back away from freeze tiles"), &g_Config.m_TcAvoidFreeze, &Column, LineSize);
+        s_SectionBoxes.back().h = Column.y - s_SectionBoxes.back().y;
 
-	// ***** Improved Anti Ping ***** //
+        // ***** Improved Anti Ping ***** //
 	Column.HSplitTop(MarginBetweenSections, nullptr, &Column);
 	s_SectionBoxes.push_back(Column);
 	Column.HSplitTop(HeadlineHeight, &Label, &Column);

--- a/src/game/client/components/tclient/menus_tclient.cpp
+++ b/src/game/client/components/tclient/menus_tclient.cpp
@@ -528,6 +528,12 @@ void CMenus::RenderSettingsTClientSettngs(CUIRect MainView)
         if(g_Config.m_TcPredMarginInFreeze)
                 Ui()->DoScrollbarOption(&g_Config.m_TcPredMarginInFreezeAmount, &g_Config.m_TcPredMarginInFreezeAmount, &Button, TCLocalize("Frozen Margin"), 0, 100, &CUi::ms_LinearScrollbarScale, 0, "ms");
         DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcAvoidFreeze, TCLocalize("Automatically back away from freeze tiles"), &g_Config.m_TcAvoidFreeze, &Column, LineSize);
+        if(g_Config.m_TcAvoidFreeze)
+        {
+                Column.HSplitTop(LineSize, &Button, &Column);
+                Ui()->DoScrollbarOption(&g_Config.m_TcAvoidFreezeRangeTiles, &g_Config.m_TcAvoidFreezeRangeTiles, &Button, TCLocalize("Freeze avoidance look-ahead"), 1, 8, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_NOCLAMPVALUE, TCLocalize(" tile(s)"));
+                DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcAvoidFreezeReleaseHook, TCLocalize("Release hook when it grabs freeze"), &g_Config.m_TcAvoidFreezeReleaseHook, &Column, LineSize);
+        }
         s_SectionBoxes.back().h = Column.y - s_SectionBoxes.back().y;
 
         // ***** Improved Anti Ping ***** //


### PR DESCRIPTION
## Summary
- add a tc_avoid_freeze client setting and expose it in the anti latency tools menu
- update controls input handling to automatically step back from nearby freeze tiles when enabled

## Testing
- cmake -S . -B build -G Ninja *(fails: glslangValidator binary missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da0c10cfa8832c866949f05f455bbf