### PR TITLE
Add auto hook avoidance and hook assist features

### DIFF
--- a/src/engine/shared/config_variables_tclient.h
+++ b/src/engine/shared/config_variables_tclient.h
@@ -41,6 +41,10 @@ MACRO_CONFIG_INT(TcRemoveAnti, tc_remove_anti, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG
 MACRO_CONFIG_INT(TcUnfreezeLagTicks, tc_remove_anti_ticks, 5, 0, 20, CFGFLAG_CLIENT | CFGFLAG_SAVE, "The biggest amount of prediction ticks that are removed")
 MACRO_CONFIG_INT(TcUnfreezeLagDelayTicks, tc_remove_anti_delay_ticks, 25, 5, 150, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How many ticks it takes to remove the maximum prediction after being frozen")
 
+MACRO_CONFIG_INT(TcAutoHookAvoidFreeze, tc_auto_hook_avoid_freeze, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Automatically start hooking when freeze tiles are below you")
+MACRO_CONFIG_INT(TcAutoHookAvoidFreezeTiles, tc_auto_hook_avoid_freeze_tiles, 3, 1, 15, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How many tiles below to scan for freeze when auto hooking")
+MACRO_CONFIG_INT(TcAutoHookAvoidFreezeVelocity, tc_auto_hook_avoid_freeze_velocity, 4, 0, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Minimum downward speed required before auto hook triggers")
+
 MACRO_CONFIG_INT(TcUnpredOthersInFreeze, tc_unpred_others_in_freeze, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Dont predict other players if you are frozen")
 MACRO_CONFIG_INT(TcPredMarginInFreeze, tc_pred_margin_in_freeze, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable changing prediction margin while frozen")
 MACRO_CONFIG_INT(TcPredMarginInFreezeAmount, tc_pred_margin_in_freeze_amount, 15, 0, 2000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Set what your prediction margin while frozen should be")
@@ -72,6 +76,11 @@ MACRO_CONFIG_INT(TcColorFreezeFeet, tc_color_freeze_feet, 0, 0, 1, CFGFLAG_CLIEN
 // Revert Variables
 MACRO_CONFIG_INT(TcSmoothPredictionMargin, tc_prediction_margin_smooth, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Makes prediction margin transition smooth, causes worse ping jitter adjustment (reverts a DDNet change)")
 MACRO_CONFIG_INT(TcFreezeKatana, tc_frozen_katana, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show katana on frozen players (reverts a DDNet change)")
+
+MACRO_CONFIG_INT(TcHookAssist, tc_hook_assist, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Assist aiming towards hookable tiles when hooking")
+MACRO_CONFIG_INT(TcHookAssistMaxAngle, tc_hook_assist_max_angle, 45, 0, 180, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Maximum angle that hook assist can adjust within")
+MACRO_CONFIG_INT(TcHookAssistSamples, tc_hook_assist_samples, 12, 1, 64, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Number of hook assist samples to search through")
+MACRO_CONFIG_INT(TcHookAssistFullCircleAuto, tc_hook_assist_full_circle_auto, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Allow hook assist to search the full circle when auto hook triggers")
 
 // Outline Variables
 MACRO_CONFIG_INT(TcOutline, tc_outline, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Draws outlines")

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -2,6 +2,8 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <base/math.h>
 
+#include <algorithm>
+
 #include <engine/client.h>
 #include <engine/shared/config.h>
 
@@ -11,10 +13,109 @@
 #include <game/client/components/scoreboard.h>
 #include <game/client/gameclient.h>
 #include <game/collision.h>
+#include <game/gamecore.h>
+#include <game/mapitems.h>
 
 #include <base/vmath.h>
 
 #include "controls.h"
+
+namespace
+{
+bool IsFreezeTileIndex(int Index)
+{
+        return Index == TILE_FREEZE || Index == TILE_DFREEZE || Index == TILE_LFREEZE;
+}
+
+bool IsFreezeTileAt(const CCollision *pCollision, vec2 Pos)
+{
+        int MapIndex = pCollision->GetPureMapIndex(Pos);
+        if(MapIndex < 0)
+                return false;
+        return IsFreezeTileIndex(pCollision->GetTileIndex(MapIndex)) || IsFreezeTileIndex(pCollision->GetFrontTileIndex(MapIndex));
+}
+
+bool HasFreezeBelow(const CCollision *pCollision, vec2 Pos, int TilesToCheck)
+{
+        if(TilesToCheck <= 0)
+                return false;
+        const float HalfSize = CCharacterCore::PhysicalSize() * 0.5f;
+        const float Step = 32.0f;
+        for(int i = 0; i < TilesToCheck; ++i)
+        {
+                const float Offset = HalfSize + (i + 0.5f) * Step;
+                const float CheckY = Pos.y + Offset;
+                if(IsFreezeTileAt(pCollision, vec2(Pos.x, CheckY)) || IsFreezeTileAt(pCollision, vec2(Pos.x - HalfSize, CheckY)) || IsFreezeTileAt(pCollision, vec2(Pos.x + HalfSize, CheckY)))
+                {
+                        return true;
+                }
+        }
+        return false;
+}
+
+bool ShouldAutoHookAvoidFreeze(const CCollision *pCollision, const CCharacterCore &Char, int TilesToCheck, int VelocityThreshold)
+{
+        if(Char.m_Super || Char.m_HookHitDisabled || Char.m_IsInFreeze || Char.m_DeepFrozen)
+                return false;
+        if(Char.m_Vel.y < static_cast<float>(VelocityThreshold))
+                return false;
+        return HasFreezeBelow(pCollision, Char.m_Pos, TilesToCheck);
+}
+
+bool FindHookAssistDirection(const CCollision *pCollision, const CCharacterCore &Char, vec2 BaseDir, float SearchAngleRad, int Samples, bool AllowFullCircle, vec2 &OutDir)
+{
+        if(Samples <= 0)
+                return false;
+        const float HookLength = Char.m_Tuning.m_HookLength;
+        if(HookLength <= 0.0f)
+                return false;
+        if(length_squared(BaseDir) < 0.0001f)
+                BaseDir = vec2(0.0f, -1.0f);
+        BaseDir = normalize(BaseDir);
+        const float StepAngle = Samples > 0 ? SearchAngleRad / static_cast<float>(Samples) : 0.0f;
+        bool Found = false;
+        float BestScore = -1000.0f;
+        for(int i = -Samples; i <= Samples; ++i)
+        {
+                const float Angle = StepAngle * static_cast<float>(i);
+                vec2 Dir = rotate(BaseDir, Angle);
+                vec2 Hit, Before;
+                int HitType = pCollision->IntersectLineTeleHook(Char.m_Pos, Char.m_Pos + Dir * HookLength, &Hit, &Before, nullptr);
+                if(HitType == 0 || HitType == TILE_NOHOOK)
+                        continue;
+
+                const float Distance = distance(Hit, Char.m_Pos);
+                const float DistanceFactor = 1.0f - std::clamp(Distance / HookLength, 0.0f, 1.0f);
+                const float Alignment = std::clamp(dot(BaseDir, Dir), -1.0f, 1.0f);
+
+                float Score = AllowFullCircle ? DistanceFactor : Alignment * 0.7f + DistanceFactor * 0.3f;
+                if(!AllowFullCircle && Score <= 0.0f)
+                        continue;
+
+                if(Score > BestScore)
+                {
+                        BestScore = Score;
+                        OutDir = Dir;
+                        Found = true;
+                }
+        }
+        return Found;
+}
+
+void ApplyHookAssist(vec2 &MousePos, const CCollision *pCollision, const CCharacterCore &Char, int Samples, float SearchAngleRad, bool AllowFullCircle)
+{
+        vec2 Dir;
+        if(!FindHookAssistDirection(pCollision, Char, MousePos, SearchAngleRad, Samples, AllowFullCircle, Dir))
+                return;
+
+        float TargetLength = length(MousePos);
+        if(TargetLength < 0.001f)
+        {
+                TargetLength = Char.m_Tuning.m_HookLength;
+        }
+        MousePos = Dir * TargetLength;
+}
+} // namespace
 
 CControls::CControls()
 {
@@ -202,90 +303,112 @@ int CControls::SnapInput(int *pData)
 		for(auto &InputData : m_aInputData)
 			InputData.m_PlayerFlags &= ~PLAYERFLAG_CHATTING;
 
-	bool Send = m_aLastData[g_Config.m_ClDummy].m_PlayerFlags != m_aInputData[g_Config.m_ClDummy].m_PlayerFlags;
+        const int Dummy = g_Config.m_ClDummy;
+        bool Send = m_aLastData[Dummy].m_PlayerFlags != m_aInputData[Dummy].m_PlayerFlags;
 
-	m_aLastData[g_Config.m_ClDummy].m_PlayerFlags = m_aInputData[g_Config.m_ClDummy].m_PlayerFlags;
+        m_aLastData[Dummy].m_PlayerFlags = m_aInputData[Dummy].m_PlayerFlags;
 
-	// we freeze the input if chat or menu is activated
-	if(!(m_aInputData[g_Config.m_ClDummy].m_PlayerFlags & PLAYERFLAG_PLAYING))
-	{
-		if(!GameClient()->m_GameInfo.m_BugDDRaceInput)
-			ResetInput(g_Config.m_ClDummy);
+        bool AutoHookTriggered = false;
+        if((m_aInputData[Dummy].m_PlayerFlags & PLAYERFLAG_PLAYING) && GameClient()->m_Snap.m_pLocalCharacter && !GameClient()->m_Snap.m_SpecInfo.m_Active)
+        {
+                const CCharacterCore &PredictedChar = GameClient()->m_PredictedChar;
+                if(g_Config.m_TcAutoHookAvoidFreeze && ShouldAutoHookAvoidFreeze(Collision(), PredictedChar, g_Config.m_TcAutoHookAvoidFreezeTiles, g_Config.m_TcAutoHookAvoidFreezeVelocity))
+                {
+                        m_aInputData[Dummy].m_Hook = 1;
+                        AutoHookTriggered = true;
+                }
 
-		mem_copy(pData, &m_aInputData[g_Config.m_ClDummy], sizeof(m_aInputData[0]));
+                if(g_Config.m_TcHookAssist && (m_aInputData[Dummy].m_Hook || AutoHookTriggered))
+                {
+                        const bool AllowFullCircle = AutoHookTriggered && g_Config.m_TcHookAssistFullCircleAuto;
+                        float SearchAngleRad = AllowFullCircle ? pi : (g_Config.m_TcHookAssistMaxAngle / 180.0f) * pi;
+                        if(SearchAngleRad < 0.0f)
+                                SearchAngleRad = 0.0f;
+                        const int Samples = maximum(1, g_Config.m_TcHookAssistSamples);
+                        ApplyHookAssist(m_aMousePos[Dummy], Collision(), PredictedChar, Samples, SearchAngleRad, AllowFullCircle);
+                }
+        }
 
-		// set the target anyway though so that we can keep seeing our surroundings,
-		// even if chat or menu are activated
-		vec2 Pos = GameClient()->m_Controls.m_aMousePos[g_Config.m_ClDummy];
-		if(g_Config.m_TcScaleMouseDistance && !GameClient()->m_Snap.m_SpecInfo.m_Active)
-		{
-			const int MaxDistance = g_Config.m_ClDyncam ? g_Config.m_ClDyncamMaxDistance : g_Config.m_ClMouseMaxDistance;
-			if(MaxDistance > 5 && MaxDistance < 1000) // Don't scale if angle bind or reduces precision
-				Pos *= 1000.0f / (float)MaxDistance;
-		}
-		m_aInputData[g_Config.m_ClDummy].m_TargetX = (int)Pos.x;
-		m_aInputData[g_Config.m_ClDummy].m_TargetY = (int)Pos.y;
+        // we freeze the input if chat or menu is activated
+        if(!(m_aInputData[Dummy].m_PlayerFlags & PLAYERFLAG_PLAYING))
+        {
+                if(!GameClient()->m_GameInfo.m_BugDDRaceInput)
+                        ResetInput(Dummy);
 
-		if(!m_aInputData[g_Config.m_ClDummy].m_TargetX && !m_aInputData[g_Config.m_ClDummy].m_TargetY)
-			m_aInputData[g_Config.m_ClDummy].m_TargetX = 1;
+                mem_copy(pData, &m_aInputData[Dummy], sizeof(m_aInputData[0]));
 
-		// send once a second just to be sure
-		Send = Send || time_get() > m_LastSendTime + time_freq();
-	}
-	else
-	{
-		vec2 Pos;
-		if(g_Config.m_ClSubTickAiming && m_aMousePosOnAction[g_Config.m_ClDummy] != vec2(0.0f, 0.0f))
-		{
-			Pos = GameClient()->m_Controls.m_aMousePos[g_Config.m_ClDummy];
-			m_aMousePosOnAction[g_Config.m_ClDummy] = vec2(0.0f, 0.0f);
-		}
-		else
-			Pos = GameClient()->m_Controls.m_aMousePos[g_Config.m_ClDummy];
+                // set the target anyway though so that we can keep seeing our surroundings,
+                // even if chat or menu are activated
+                vec2 Pos = GameClient()->m_Controls.m_aMousePos[Dummy];
+                if(g_Config.m_TcScaleMouseDistance && !GameClient()->m_Snap.m_SpecInfo.m_Active)
+                {
+                        const int MaxDistance = g_Config.m_ClDyncam ? g_Config.m_ClDyncamMaxDistance : g_Config.m_ClMouseMaxDistance;
+                        if(MaxDistance > 5 && MaxDistance < 1000) // Don't scale if angle bind or reduces precision
+                                Pos *= 1000.0f / (float)MaxDistance;
+                }
+                m_aInputData[Dummy].m_TargetX = (int)Pos.x;
+                m_aInputData[Dummy].m_TargetY = (int)Pos.y;
 
-		if(g_Config.m_TcScaleMouseDistance && !GameClient()->m_Snap.m_SpecInfo.m_Active)
-		{
-			const int MaxDistance = g_Config.m_ClDyncam ? g_Config.m_ClDyncamMaxDistance : g_Config.m_ClMouseMaxDistance;
-			if(MaxDistance > 5 && MaxDistance < 1000) // Don't scale if angle bind or reduces precision
-				Pos *= 1000.0f / (float)MaxDistance;
-		}
-		m_aInputData[g_Config.m_ClDummy].m_TargetX = (int)Pos.x;
-		m_aInputData[g_Config.m_ClDummy].m_TargetY = (int)Pos.y;
+                if(!m_aInputData[Dummy].m_TargetX && !m_aInputData[Dummy].m_TargetY)
+                        m_aInputData[Dummy].m_TargetX = 1;
 
-		if(!m_aInputData[g_Config.m_ClDummy].m_TargetX && !m_aInputData[g_Config.m_ClDummy].m_TargetY)
-			m_aInputData[g_Config.m_ClDummy].m_TargetX = 1;
+                // send once a second just to be sure
+                Send = Send || time_get() > m_LastSendTime + time_freq();
+        }
+        else
+        {
+                vec2 Pos;
+                if(g_Config.m_ClSubTickAiming && m_aMousePosOnAction[Dummy] != vec2(0.0f, 0.0f))
+                {
+                        Pos = GameClient()->m_Controls.m_aMousePos[Dummy];
+                        m_aMousePosOnAction[Dummy] = vec2(0.0f, 0.0f);
+                }
+                else
+                        Pos = GameClient()->m_Controls.m_aMousePos[Dummy];
 
-		// set direction
-		m_aInputData[g_Config.m_ClDummy].m_Direction = 0;
-		if(m_aInputDirectionLeft[g_Config.m_ClDummy] && !m_aInputDirectionRight[g_Config.m_ClDummy])
-			m_aInputData[g_Config.m_ClDummy].m_Direction = -1;
-		if(!m_aInputDirectionLeft[g_Config.m_ClDummy] && m_aInputDirectionRight[g_Config.m_ClDummy])
-			m_aInputData[g_Config.m_ClDummy].m_Direction = 1;
+                if(g_Config.m_TcScaleMouseDistance && !GameClient()->m_Snap.m_SpecInfo.m_Active)
+                {
+                        const int MaxDistance = g_Config.m_ClDyncam ? g_Config.m_ClDyncamMaxDistance : g_Config.m_ClMouseMaxDistance;
+                        if(MaxDistance > 5 && MaxDistance < 1000) // Don't scale if angle bind or reduces precision
+                                Pos *= 1000.0f / (float)MaxDistance;
+                }
+                m_aInputData[Dummy].m_TargetX = (int)Pos.x;
+                m_aInputData[Dummy].m_TargetY = (int)Pos.y;
 
-		// dummy copy moves
-		if(g_Config.m_ClDummyCopyMoves)
-		{
-			CNetObj_PlayerInput *pDummyInput = &GameClient()->m_DummyInput;
-			pDummyInput->m_Direction = m_aInputData[g_Config.m_ClDummy].m_Direction;
-			pDummyInput->m_Hook = m_aInputData[g_Config.m_ClDummy].m_Hook;
-			pDummyInput->m_Jump = m_aInputData[g_Config.m_ClDummy].m_Jump;
-			pDummyInput->m_PlayerFlags = m_aInputData[g_Config.m_ClDummy].m_PlayerFlags;
-			pDummyInput->m_TargetX = m_aInputData[g_Config.m_ClDummy].m_TargetX;
-			pDummyInput->m_TargetY = m_aInputData[g_Config.m_ClDummy].m_TargetY;
-			pDummyInput->m_WantedWeapon = m_aInputData[g_Config.m_ClDummy].m_WantedWeapon;
+                if(!m_aInputData[Dummy].m_TargetX && !m_aInputData[Dummy].m_TargetY)
+                        m_aInputData[Dummy].m_TargetX = 1;
 
-			if(!g_Config.m_ClDummyControl)
-				pDummyInput->m_Fire += m_aInputData[g_Config.m_ClDummy].m_Fire - m_aLastData[g_Config.m_ClDummy].m_Fire;
+                // set direction
+                m_aInputData[Dummy].m_Direction = 0;
+                if(m_aInputDirectionLeft[Dummy] && !m_aInputDirectionRight[Dummy])
+                        m_aInputData[Dummy].m_Direction = -1;
+                if(!m_aInputDirectionLeft[Dummy] && m_aInputDirectionRight[Dummy])
+                        m_aInputData[Dummy].m_Direction = 1;
 
-			pDummyInput->m_NextWeapon += m_aInputData[g_Config.m_ClDummy].m_NextWeapon - m_aLastData[g_Config.m_ClDummy].m_NextWeapon;
-			pDummyInput->m_PrevWeapon += m_aInputData[g_Config.m_ClDummy].m_PrevWeapon - m_aLastData[g_Config.m_ClDummy].m_PrevWeapon;
+                // dummy copy moves
+                if(g_Config.m_ClDummyCopyMoves)
+                {
+                        CNetObj_PlayerInput *pDummyInput = &GameClient()->m_DummyInput;
+                        pDummyInput->m_Direction = m_aInputData[Dummy].m_Direction;
+                        pDummyInput->m_Hook = m_aInputData[Dummy].m_Hook;
+                        pDummyInput->m_Jump = m_aInputData[Dummy].m_Jump;
+                        pDummyInput->m_PlayerFlags = m_aInputData[Dummy].m_PlayerFlags;
+                        pDummyInput->m_TargetX = m_aInputData[Dummy].m_TargetX;
+                        pDummyInput->m_TargetY = m_aInputData[Dummy].m_TargetY;
+                        pDummyInput->m_WantedWeapon = m_aInputData[Dummy].m_WantedWeapon;
 
-			m_aInputData[!g_Config.m_ClDummy] = *pDummyInput;
-		}
+                        if(!g_Config.m_ClDummyControl)
+                                pDummyInput->m_Fire += m_aInputData[Dummy].m_Fire - m_aLastData[Dummy].m_Fire;
 
-		if(g_Config.m_ClDummyControl)
-		{
-			CNetObj_PlayerInput *pDummyInput = &GameClient()->m_DummyInput;
+                        pDummyInput->m_NextWeapon += m_aInputData[Dummy].m_NextWeapon - m_aLastData[Dummy].m_NextWeapon;
+                        pDummyInput->m_PrevWeapon += m_aInputData[Dummy].m_PrevWeapon - m_aLastData[Dummy].m_PrevWeapon;
+
+                        m_aInputData[!Dummy] = *pDummyInput;
+                }
+
+                if(g_Config.m_ClDummyControl)
+                {
+                        CNetObj_PlayerInput *pDummyInput = &GameClient()->m_DummyInput;
 			pDummyInput->m_Jump = g_Config.m_ClDummyJump;
 
 			if(g_Config.m_ClDummyFire)
@@ -313,8 +436,8 @@ int CControls::SnapInput(int *pData)
 		}
 #endif
 		// check if we need to send input
-		Send = Send || m_aInputData[g_Config.m_ClDummy].m_Direction != m_aLastData[g_Config.m_ClDummy].m_Direction;
-		Send = Send || m_aInputData[g_Config.m_ClDummy].m_Jump != m_aLastData[g_Config.m_ClDummy].m_Jump;
+                Send = Send || m_aInputData[Dummy].m_Direction != m_aLastData[Dummy].m_Direction;
+                Send = Send || m_aInputData[Dummy].m_Jump != m_aLastData[Dummy].m_Jump;
 		Send = Send || m_aInputData[g_Config.m_ClDummy].m_Fire != m_aLastData[g_Config.m_ClDummy].m_Fire;
 		Send = Send || m_aInputData[g_Config.m_ClDummy].m_Hook != m_aLastData[g_Config.m_ClDummy].m_Hook;
 		Send = Send || m_aInputData[g_Config.m_ClDummy].m_WantedWeapon != m_aLastData[g_Config.m_ClDummy].m_WantedWeapon;

--- a/src/game/client/components/tclient/menus_tclient.cpp
+++ b/src/game/client/components/tclient/menus_tclient.cpp
@@ -527,9 +527,42 @@ void CMenus::RenderSettingsTClientSettngs(CUIRect MainView)
 	Column.HSplitTop(LineSize, &Button, &Column);
 	if(g_Config.m_TcPredMarginInFreeze)
 		Ui()->DoScrollbarOption(&g_Config.m_TcPredMarginInFreezeAmount, &g_Config.m_TcPredMarginInFreezeAmount, &Button, TCLocalize("Frozen Margin"), 0, 100, &CUi::ms_LinearScrollbarScale, 0, "ms");
-	s_SectionBoxes.back().h = Column.y - s_SectionBoxes.back().y;
+        s_SectionBoxes.back().h = Column.y - s_SectionBoxes.back().y;
 
-	// ***** Improved Anti Ping ***** //
+        // ***** Hook Automation ***** //
+        Column.HSplitTop(MarginBetweenSections, nullptr, &Column);
+        s_SectionBoxes.push_back(Column);
+        Column.HSplitTop(HeadlineHeight, &Label, &Column);
+        Ui()->DoLabel(&Label, TCLocalize("Hook Automation"), HeadlineFontSize, TEXTALIGN_ML);
+        Column.HSplitTop(MarginSmall, nullptr, &Column);
+
+        DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcAutoHookAvoidFreeze, TCLocalize("Auto hook near freeze"), &g_Config.m_TcAutoHookAvoidFreeze, &Column, LineSize);
+        if(g_Config.m_TcAutoHookAvoidFreeze)
+        {
+                Column.HSplitTop(LineSize, &Button, &Column);
+                Ui()->DoScrollbarOption(&g_Config.m_TcAutoHookAvoidFreezeTiles, &g_Config.m_TcAutoHookAvoidFreezeTiles, &Button, TCLocalize("Scan distance"), 1, 15, &CUi::ms_LinearScrollbarScale, 0, TCLocalize(" tiles"));
+                Column.HSplitTop(LineSize, &Button, &Column);
+                Ui()->DoScrollbarOption(&g_Config.m_TcAutoHookAvoidFreezeVelocity, &g_Config.m_TcAutoHookAvoidFreezeVelocity, &Button, TCLocalize("Trigger fall speed"), 0, 50, &CUi::ms_LinearScrollbarScale, 0, TCLocalize(" uu/tick"));
+        }
+        else
+        {
+                Column.HSplitTop(LineSize * 2, nullptr, &Column);
+        }
+
+        Column.HSplitTop(MarginSmall, nullptr, &Column);
+        DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcHookAssist, TCLocalize("Hook assist"), &g_Config.m_TcHookAssist, &Column, LineSize);
+        if(g_Config.m_TcHookAssist)
+        {
+                Column.HSplitTop(LineSize, &Button, &Column);
+                Ui()->DoScrollbarOption(&g_Config.m_TcHookAssistMaxAngle, &g_Config.m_TcHookAssistMaxAngle, &Button, TCLocalize("Assist angle"), 0, 180, &CUi::ms_LinearScrollbarScale, 0, "°");
+                Column.HSplitTop(LineSize, &Button, &Column);
+                Ui()->DoScrollbarOption(&g_Config.m_TcHookAssistSamples, &g_Config.m_TcHookAssistSamples, &Button, TCLocalize("Assist samples"), 1, 64);
+                DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcHookAssistFullCircleAuto, TCLocalize("Full circle search during auto hook"), &g_Config.m_TcHookAssistFullCircleAuto, &Column, LineSize);
+        }
+        Column.HSplitTop(MarginExtraSmall, nullptr, &Column);
+        s_SectionBoxes.back().h = Column.y - s_SectionBoxes.back().y;
+
+        // ***** Improved Anti Ping ***** //
 	Column.HSplitTop(MarginBetweenSections, nullptr, &Column);
 	s_SectionBoxes.push_back(Column);
 	Column.HSplitTop(HeadlineHeight, &Label, &Column);


### PR DESCRIPTION
## Summary
- add configuration flags for auto hook freeze avoidance and hook assist options
- implement client logic to trigger auto hook when freeze tiles are below and adjust aim toward hookable surfaces
- expose the new automation controls in the TClient settings menu

## Testing
- cmake -S . -B build *(fails: glslangValidator missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da15474818832c9302e996f4ff52e9