### PR TITLE
Improve avoid freeze control and expose helper settings

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -700,6 +700,11 @@ MACRO_CONFIG_STR(SvConnLoggingServer, sv_conn_logging_server, 128, "", CFGFLAG_S
 
 MACRO_CONFIG_INT(ClUnpredictedShadow, cl_unpredicted_shadow, 0, -1, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show unpredicted shadow tee (0 = off, 1 = on, -1 = don't even show in debug mode)")
 MACRO_CONFIG_INT(ClPredictFreeze, cl_predict_freeze, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict freeze tiles (0 = off, 1 = on, 2 = partial (allow a small amount of movement in freeze)")
+MACRO_CONFIG_INT(ClAvoidFreeze, cl_avoid_freeze, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Automatically move away from hooked freeze tiles")
+MACRO_CONFIG_INT(ClAvoidFreezeHold, cl_avoid_freeze_hold, 180, 0, 1000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How long to continue moving after avoiding a freeze tile (in ms)")
+MACRO_CONFIG_INT(ClHookAssist, cl_hook_assist, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Adjust hook aim towards nearby tees when starting a hook")
+MACRO_CONFIG_INT(ClHookAssistRange, cl_hook_assist_range, 25, 1, 90, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Maximum angle difference in degrees for hook assist to snap")
+MACRO_CONFIG_INT(ClHookAssistMaxDist, cl_hook_assist_max_dist, 450, 50, 1000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Maximum distance in units for hook assist targets")
 MACRO_CONFIG_INT(ClShowNinja, cl_show_ninja, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ninja skin")
 MACRO_CONFIG_INT(ClShowHookCollOther, cl_show_hook_coll_other, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show other players' hook collision line (2 to always show)")
 MACRO_CONFIG_INT(ClShowHookCollOwn, cl_show_hook_coll_own, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show own players' hook collision line (2 to always show)")

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -2,6 +2,9 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <base/math.h>
 
+#include <algorithm>
+#include <cmath>
+
 #include <engine/client.h>
 #include <engine/shared/config.h>
 
@@ -11,10 +14,41 @@
 #include <game/client/components/scoreboard.h>
 #include <game/client/gameclient.h>
 #include <game/collision.h>
+#include <game/mapitems.h>
 
 #include <base/vmath.h>
 
 #include "controls.h"
+
+namespace
+{
+bool IsFreezeTile(int Tile)
+{
+	return Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE;
+}
+
+bool IsFreezeTileAt(const CCollision *pCollision, const vec2 &Pos)
+{
+	if(!pCollision)
+		return false;
+	const int Index = pCollision->GetPureMapIndex(Pos);
+	if(Index < 0)
+		return false;
+	if(IsFreezeTile(pCollision->GetTileIndex(Index)))
+		return true;
+	return IsFreezeTile(pCollision->GetFrontTileIndex(Index));
+}
+
+float AngleBetween(const vec2 &a, const vec2 &b)
+{
+	const float LengthA = length(a);
+	const float LengthB = length(b);
+	if(LengthA < 1e-6f || LengthB < 1e-6f)
+		return 0.0f;
+	const float Dot = std::clamp(dot(a, b) / (LengthA * LengthB), -1.0f, 1.0f);
+	return std::acos(Dot);
+}
+} // namespace
 
 CControls::CControls()
 {
@@ -22,6 +56,9 @@ CControls::CControls()
 	mem_zero(m_aMousePos, sizeof(m_aMousePos));
 	mem_zero(m_aMousePosOnAction, sizeof(m_aMousePosOnAction));
 	mem_zero(m_aTargetPos, sizeof(m_aTargetPos));
+	mem_zero(m_aAvoidFreezeTimer, sizeof(m_aAvoidFreezeTimer));
+	mem_zero(m_aAvoidFreezeDir, sizeof(m_aAvoidFreezeDir));
+	mem_zero(m_aHookAssistLock, sizeof(m_aHookAssistLock));
 }
 
 void CControls::OnReset()
@@ -47,6 +84,9 @@ void CControls::ResetInput(int Dummy)
 
 	m_aInputDirectionLeft[Dummy] = 0;
 	m_aInputDirectionRight[Dummy] = 0;
+	m_aAvoidFreezeTimer[Dummy] = 0;
+	m_aAvoidFreezeDir[Dummy] = 0;
+	m_aHookAssistLock[Dummy] = false;
 }
 
 void CControls::OnPlayerDeath()
@@ -294,6 +334,131 @@ int CControls::SnapInput(int *pData)
 				pDummyInput->m_Fire++;
 
 			pDummyInput->m_Hook = g_Config.m_ClDummyHook;
+		}
+
+		const int Dummy = g_Config.m_ClDummy;
+		if(g_Config.m_ClAvoidFreeze && !GameClient()->m_Snap.m_SpecInfo.m_Active)
+		{
+			int &AvoidTimer = m_aAvoidFreezeTimer[Dummy];
+			int &AvoidDir = m_aAvoidFreezeDir[Dummy];
+			const int LocalId = GameClient()->m_Snap.m_LocalClientId;
+			if(LocalId >= 0 && GameClient()->m_aClients[LocalId].m_Active)
+			{
+				const CCharacterCore &LocalCore = GameClient()->m_aClients[LocalId].m_Predicted;
+				const bool HookingFreeze = LocalCore.m_HookState == HOOK_GRABBED && LocalCore.HookedPlayer() == -1 && IsFreezeTileAt(Collision(), LocalCore.m_HookPos);
+				if(HookingFreeze)
+				{
+					vec2 Avoid = LocalCore.m_Pos - LocalCore.m_HookPos;
+					int Dir = 0;
+					if(std::abs(Avoid.x) > 1.0f || std::abs(LocalCore.m_Vel.x) > 1.0f)
+					{
+						if(std::abs(Avoid.x) >= std::abs(Avoid.y) * 0.5f)
+							Dir = Avoid.x > 0.0f ? 1 : -1;
+						else if(std::abs(LocalCore.m_Vel.x) > 1.0f)
+							Dir = LocalCore.m_Vel.x > 0.0f ? 1 : -1;
+					}
+					if(Dir != 0)
+					{
+						AvoidDir = Dir;
+						const int Duration = std::max(1, g_Config.m_ClAvoidFreezeHold * Client()->GameTickSpeed() / 1000);
+						AvoidTimer = std::max(AvoidTimer, Duration);
+					}
+				}
+				if(AvoidTimer > 0 && AvoidDir != 0)
+				{
+					if(m_aInputDirectionLeft[Dummy] == 0 && m_aInputDirectionRight[Dummy] == 0)
+						m_aInputData[Dummy].m_Direction = AvoidDir;
+					if(--AvoidTimer <= 0)
+						AvoidDir = 0;
+				}
+			}
+			else
+			{
+				AvoidTimer = 0;
+				AvoidDir = 0;
+			}
+		}
+		else
+		{
+			m_aAvoidFreezeTimer[Dummy] = 0;
+			m_aAvoidFreezeDir[Dummy] = 0;
+		}
+
+		if(g_Config.m_ClHookAssist && !GameClient()->m_Snap.m_SpecInfo.m_Active)
+		{
+			const int LocalId = GameClient()->m_Snap.m_LocalClientId;
+			if(LocalId >= 0 && GameClient()->m_aClients[LocalId].m_Active)
+			{
+				const CGameClient::CClientData &LocalClient = GameClient()->m_aClients[LocalId];
+				if(!LocalClient.m_HookHitDisabled && !LocalClient.m_Solo)
+				{
+					const bool HookPressed = (m_aInputData[Dummy].m_Hook & 1) != 0;
+					if(!HookPressed)
+					{
+						m_aHookAssistLock[Dummy] = false;
+					}
+					else if(!m_aHookAssistLock[Dummy] && (m_aLastData[Dummy].m_Hook & 1) == 0)
+					{
+						vec2 Aim = vec2(m_aInputData[Dummy].m_TargetX, m_aInputData[Dummy].m_TargetY);
+						if(length(Aim) > 0.001f)
+						{
+							const float MaxDist = (float)g_Config.m_ClHookAssistMaxDist;
+							float BestAngle = (float)g_Config.m_ClHookAssistRange * pi / 180.0f;
+							float BestDist = MaxDist;
+							vec2 BestVec = vec2(0, 0);
+							bool FoundTarget = false;
+							const vec2 LocalPos = LocalClient.m_Predicted.m_Pos;
+							for(int i = 0; i < MAX_CLIENTS; ++i)
+							{
+								if(i == LocalId)
+									continue;
+								const CGameClient::CClientData &Client = GameClient()->m_aClients[i];
+								if(!Client.m_Active || Client.m_HookHitDisabled)
+									continue;
+								if(Client.m_Solo)
+									continue;
+								if(!GameClient()->m_Snap.m_aCharacters[i].m_Active)
+									continue;
+								vec2 ToTarget = Client.m_Predicted.m_Pos - LocalPos;
+								const float Dist = length(ToTarget);
+								if(Dist < 1.0f || Dist > MaxDist)
+									continue;
+								const float Angle = AngleBetween(Aim, ToTarget);
+								if(Angle > (float)g_Config.m_ClHookAssistRange * pi / 180.0f)
+									continue;
+								if(GameClient()->Collision()->IntersectLineTeleHook(LocalPos, Client.m_Predicted.m_Pos, nullptr, nullptr))
+									continue;
+								if(!FoundTarget || Angle < BestAngle || (std::abs(Angle - BestAngle) < 1e-3f && Dist < BestDist))
+								{
+									FoundTarget = true;
+									BestAngle = Angle;
+									BestDist = Dist;
+									BestVec = ToTarget;
+								}
+							}
+							if(FoundTarget && length(BestVec) > 0.001f)
+							{
+								const float MinDistance = GetMinMouseDistance();
+								const float MaxDistance = GetMaxMouseDistance();
+								float DesiredLength = std::clamp(length(BestVec), MinDistance, MaxDistance);
+								vec2 AimVec = normalize(BestVec) * DesiredLength;
+								m_aMousePos[Dummy] = AimVec;
+								m_aInputData[Dummy].m_TargetX = (int)AimVec.x;
+								m_aInputData[Dummy].m_TargetY = (int)AimVec.y;
+								m_aHookAssistLock[Dummy] = true;
+							}
+						}
+					}
+				}
+				else
+				{
+					m_aHookAssistLock[Dummy] = false;
+				}
+			}
+		}
+		else
+		{
+			m_aHookAssistLock[Dummy] = false;
 		}
 
 		// stress testing

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -23,6 +23,10 @@ public:
 
 	int m_aAmmoCount[NUM_WEAPONS];
 
+	int m_aAvoidFreezeTimer[NUM_DUMMIES];
+	int m_aAvoidFreezeDir[NUM_DUMMIES];
+	bool m_aHookAssistLock[NUM_DUMMIES];
+
 	int64_t m_LastSendTime;
 	CNetObj_PlayerInput m_aInputData[NUM_DUMMIES];
 	CNetObj_PlayerInput m_aLastData[NUM_DUMMIES];

--- a/src/game/client/components/tclient/menus_tclient.cpp
+++ b/src/game/client/components/tclient/menus_tclient.cpp
@@ -501,6 +501,27 @@ void CMenus::RenderSettingsTClientSettngs(CUIRect MainView)
 
 	s_SectionBoxes.back().h = Column.y - s_SectionBoxes.back().y;
 
+	// ***** Helpers ***** //
+	Column.HSplitTop(MarginBetweenSections, nullptr, &Column);
+	s_SectionBoxes.push_back(Column);
+	Column.HSplitTop(HeadlineHeight, &Label, &Column);
+	Ui()->DoLabel(&Label, TCLocalize("Helpers"), HeadlineFontSize, TEXTALIGN_ML);
+	Column.HSplitTop(MarginSmall, nullptr, &Column);
+
+	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClAvoidFreeze, TCLocalize("Avoid freeze tiles"), &g_Config.m_ClAvoidFreeze, &Column, LineSize);
+	Column.HSplitTop(LineSize, &Button, &Column);
+	Ui()->DoScrollbarOption(&g_Config.m_ClAvoidFreezeHold, &g_Config.m_ClAvoidFreezeHold, &Button,
+		g_Config.m_ClAvoidFreeze ? TCLocalize("Avoid freeze hold") : TCLocalize("Avoid freeze hold (inactive)"),
+		0, 1000, &CUi::ms_LinearScrollbarScale, 0, "ms");
+
+	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClHookAssist, TCLocalize("Hook assist"), &g_Config.m_ClHookAssist, &Column, LineSize);
+	Column.HSplitTop(LineSize, &Button, &Column);
+	Ui()->DoScrollbarOption(&g_Config.m_ClHookAssistRange, &g_Config.m_ClHookAssistRange, &Button, TCLocalize("Hook assist angle"), 1, 90, &CUi::ms_LinearScrollbarScale, 0, "°");
+	Column.HSplitTop(LineSize, &Button, &Column);
+	Ui()->DoScrollbarOption(&g_Config.m_ClHookAssistMaxDist, &g_Config.m_ClHookAssistMaxDist, &Button, TCLocalize("Hook assist distance"), 50, 1000, &CUi::ms_LinearScrollbarScale, 0, "u");
+
+	s_SectionBoxes.back().h = Column.y - s_SectionBoxes.back().y;
+
 	// ***** Anti Latency Tools ***** //
 	Column.HSplitTop(MarginBetweenSections, nullptr, &Column);
 	s_SectionBoxes.push_back(Column);


### PR DESCRIPTION
## Summary
- add client configuration variables for avoid-freeze and hook-assist helpers
- implement automatic freeze avoidance and hook assist aim snapping in the controls component
- expose helper options in the TClient settings UI for easier configuration

## Testing
- cmake -S . -B build -GNinja *(fails: missing glslangValidator in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da1a72e93c832c819eb43ba2d38e32