### PR TITLE
Remove avoid-freeze automation from controls

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -700,8 +700,6 @@ MACRO_CONFIG_STR(SvConnLoggingServer, sv_conn_logging_server, 128, "", CFGFLAG_S
 
 MACRO_CONFIG_INT(ClUnpredictedShadow, cl_unpredicted_shadow, 0, -1, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show unpredicted shadow tee (0 = off, 1 = on, -1 = don't even show in debug mode)")
 MACRO_CONFIG_INT(ClPredictFreeze, cl_predict_freeze, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict freeze tiles (0 = off, 1 = on, 2 = partial (allow a small amount of movement in freeze)")
-MACRO_CONFIG_INT(ClAvoidFreeze, cl_avoid_freeze, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Automatically move away from hooked freeze tiles")
-MACRO_CONFIG_INT(ClAvoidFreezeHold, cl_avoid_freeze_hold, 180, 0, 1000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How long to continue moving after avoiding a freeze tile (in ms)")
 MACRO_CONFIG_INT(ClHookAssist, cl_hook_assist, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Adjust hook aim towards nearby tees when starting a hook")
 MACRO_CONFIG_INT(ClHookAssistRange, cl_hook_assist_range, 25, 1, 90, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Maximum angle difference in degrees for hook assist to snap")
 MACRO_CONFIG_INT(ClHookAssistMaxDist, cl_hook_assist_max_dist, 450, 50, 1000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Maximum distance in units for hook assist targets")

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -22,23 +22,6 @@
 
 namespace
 {
-bool IsFreezeTile(int Tile)
-{
-	return Tile == TILE_FREEZE || Tile == TILE_DFREEZE || Tile == TILE_LFREEZE;
-}
-
-bool IsFreezeTileAt(const CCollision *pCollision, const vec2 &Pos)
-{
-	if(!pCollision)
-		return false;
-	const int Index = pCollision->GetPureMapIndex(Pos);
-	if(Index < 0)
-		return false;
-	if(IsFreezeTile(pCollision->GetTileIndex(Index)))
-		return true;
-	return IsFreezeTile(pCollision->GetFrontTileIndex(Index));
-}
-
 float AngleBetween(const vec2 &a, const vec2 &b)
 {
 	const float LengthA = length(a);
@@ -56,8 +39,6 @@ CControls::CControls()
 	mem_zero(m_aMousePos, sizeof(m_aMousePos));
 	mem_zero(m_aMousePosOnAction, sizeof(m_aMousePosOnAction));
 	mem_zero(m_aTargetPos, sizeof(m_aTargetPos));
-	mem_zero(m_aAvoidFreezeTimer, sizeof(m_aAvoidFreezeTimer));
-	mem_zero(m_aAvoidFreezeDir, sizeof(m_aAvoidFreezeDir));
 	mem_zero(m_aHookAssistLock, sizeof(m_aHookAssistLock));
 }
 
@@ -84,8 +65,6 @@ void CControls::ResetInput(int Dummy)
 
 	m_aInputDirectionLeft[Dummy] = 0;
 	m_aInputDirectionRight[Dummy] = 0;
-	m_aAvoidFreezeTimer[Dummy] = 0;
-	m_aAvoidFreezeDir[Dummy] = 0;
 	m_aHookAssistLock[Dummy] = false;
 }
 
@@ -336,55 +315,8 @@ int CControls::SnapInput(int *pData)
 			pDummyInput->m_Hook = g_Config.m_ClDummyHook;
 		}
 
-		const int Dummy = g_Config.m_ClDummy;
-		if(g_Config.m_ClAvoidFreeze && !GameClient()->m_Snap.m_SpecInfo.m_Active)
-		{
-			int &AvoidTimer = m_aAvoidFreezeTimer[Dummy];
-			int &AvoidDir = m_aAvoidFreezeDir[Dummy];
-			const int LocalId = GameClient()->m_Snap.m_LocalClientId;
-			if(LocalId >= 0 && GameClient()->m_aClients[LocalId].m_Active)
-			{
-				const CCharacterCore &LocalCore = GameClient()->m_aClients[LocalId].m_Predicted;
-				const bool HookingFreeze = LocalCore.m_HookState == HOOK_GRABBED && LocalCore.HookedPlayer() == -1 && IsFreezeTileAt(Collision(), LocalCore.m_HookPos);
-				if(HookingFreeze)
-				{
-					vec2 Avoid = LocalCore.m_Pos - LocalCore.m_HookPos;
-					int Dir = 0;
-					if(std::abs(Avoid.x) > 1.0f || std::abs(LocalCore.m_Vel.x) > 1.0f)
-					{
-						if(std::abs(Avoid.x) >= std::abs(Avoid.y) * 0.5f)
-							Dir = Avoid.x > 0.0f ? 1 : -1;
-						else if(std::abs(LocalCore.m_Vel.x) > 1.0f)
-							Dir = LocalCore.m_Vel.x > 0.0f ? 1 : -1;
-					}
-					if(Dir != 0)
-					{
-						AvoidDir = Dir;
-						const int Duration = std::max(1, g_Config.m_ClAvoidFreezeHold * Client()->GameTickSpeed() / 1000);
-						AvoidTimer = std::max(AvoidTimer, Duration);
-					}
-				}
-				if(AvoidTimer > 0 && AvoidDir != 0)
-				{
-					if(m_aInputDirectionLeft[Dummy] == 0 && m_aInputDirectionRight[Dummy] == 0)
-						m_aInputData[Dummy].m_Direction = AvoidDir;
-					if(--AvoidTimer <= 0)
-						AvoidDir = 0;
-				}
-			}
-			else
-			{
-				AvoidTimer = 0;
-				AvoidDir = 0;
-			}
-		}
-		else
-		{
-			m_aAvoidFreezeTimer[Dummy] = 0;
-			m_aAvoidFreezeDir[Dummy] = 0;
-		}
-
-		if(g_Config.m_ClHookAssist && !GameClient()->m_Snap.m_SpecInfo.m_Active)
+                const int Dummy = g_Config.m_ClDummy;
+                if(g_Config.m_ClHookAssist && !GameClient()->m_Snap.m_SpecInfo.m_Active)
 		{
 			const int LocalId = GameClient()->m_Snap.m_LocalClientId;
 			if(LocalId >= 0 && GameClient()->m_aClients[LocalId].m_Active)

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -23,8 +23,6 @@ public:
 
 	int m_aAmmoCount[NUM_WEAPONS];
 
-	int m_aAvoidFreezeTimer[NUM_DUMMIES];
-	int m_aAvoidFreezeDir[NUM_DUMMIES];
 	bool m_aHookAssistLock[NUM_DUMMIES];
 
 	int64_t m_LastSendTime;

--- a/src/game/client/components/tclient/menus_tclient.cpp
+++ b/src/game/client/components/tclient/menus_tclient.cpp
@@ -508,12 +508,6 @@ void CMenus::RenderSettingsTClientSettngs(CUIRect MainView)
 	Ui()->DoLabel(&Label, TCLocalize("Helpers"), HeadlineFontSize, TEXTALIGN_ML);
 	Column.HSplitTop(MarginSmall, nullptr, &Column);
 
-	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClAvoidFreeze, TCLocalize("Avoid freeze tiles"), &g_Config.m_ClAvoidFreeze, &Column, LineSize);
-	Column.HSplitTop(LineSize, &Button, &Column);
-	Ui()->DoScrollbarOption(&g_Config.m_ClAvoidFreezeHold, &g_Config.m_ClAvoidFreezeHold, &Button,
-		g_Config.m_ClAvoidFreeze ? TCLocalize("Avoid freeze hold") : TCLocalize("Avoid freeze hold (inactive)"),
-		0, 1000, &CUi::ms_LinearScrollbarScale, 0, "ms");
-
 	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClHookAssist, TCLocalize("Hook assist"), &g_Config.m_ClHookAssist, &Column, LineSize);
 	Column.HSplitTop(LineSize, &Button, &Column);
 	Ui()->DoScrollbarOption(&g_Config.m_ClHookAssistRange, &g_Config.m_ClHookAssistRange, &Button, TCLocalize("Hook assist angle"), 1, 90, &CUi::ms_LinearScrollbarScale, 0, "°");


### PR DESCRIPTION
## Summary
- remove the avoid-freeze configuration options and all related client logic
- keep the hook assist helper active independently and leave its settings in the helpers menu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da214fd104832c97a1ec09e6b6289e